### PR TITLE
Upgrade grpcutils to 0.1.3 to support binary headers

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,4 +10,8 @@ ignore:
     - '*':
         reason: no available replacement
         expires: 2020-07-31T00:00:00.000Z
+  SNYK-JAVA-IOGRPC-571957:
+    - '*':
+        reason: No replacement available
+        expires: 2020-08-31T00:00:00.000Z
 patch: {}

--- a/hypertrace-federated-service/build.gradle.kts
+++ b/hypertrace-federated-service/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation("org.hypertrace.gateway.service:gateway-service")
   implementation("org.hypertrace.gateway.service:gateway-service-impl")
 
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.3")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.4")
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.1.3")
   implementation("org.hypertrace.core.documentstore:document-store:0.1.1")
 

--- a/hypertrace-federated-service/build.gradle.kts
+++ b/hypertrace-federated-service/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   implementation("org.hypertrace.gateway.service:gateway-service-impl")
 
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.3")
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.1.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.1.3")
   implementation("org.hypertrace.core.documentstore:document-store:0.1.1")
 
   // Logging


### PR DESCRIPTION
Upgrade grpcutils for 0.1.3 to support binary headers