### PR TITLE
Updates to latest docker plugin inlining port and healthcheck config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
   id("org.hypertrace.repository-plugin") version "0.2.1"
   id("org.hypertrace.ci-utils-plugin") version "0.1.2"
-  id("org.hypertrace.docker-java-application-plugin") version "0.4.0" apply false
-  id("org.hypertrace.docker-publish-plugin") version "0.4.0" apply false
+  id("org.hypertrace.docker-java-application-plugin") version "0.5.1" apply false
+  id("org.hypertrace.docker-publish-plugin") version "0.5.1" apply false
   id("org.hypertrace.jacoco-report-plugin") version "0.1.1" apply false
 }
 

--- a/hypertrace-federated-service/build.gradle.kts
+++ b/hypertrace-federated-service/build.gradle.kts
@@ -38,6 +38,15 @@ application {
   mainClassName = "org.hypertrace.core.serviceframework.PlatformServiceLauncher"
 }
 
+hypertraceDocker {
+  defaultImage {
+    javaApplication {
+      serviceName.set("${project.name}")
+      port.set(9001)
+    }
+  }
+}
+
 // Config for gw run to be able to run this locally. Just execute gw run here on Intellij or on the console.
 tasks.run<JavaExec> {
   jvmArgs = listOf("-Dbootstrap.config.uri=file:${project.buildDir}/resources/main/configs", "-Dservice.name=${project.name}")


### PR DESCRIPTION
after:
```
hypertrace-federated-service   java -cp /app/resources:/a ...   Up (healthy)   9001/tcp, 9002/tcp                                                               ```