### PR TITLE
adds waiting time for UI server startup

### DIFF
--- a/hypertrace-federated-service/build.gradle.kts
+++ b/hypertrace-federated-service/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
   implementation("org.hypertrace.entity.service:entity-service-impl")
   implementation("org.hypertrace.core.query.service:query-service")
   implementation("org.hypertrace.core.query.service:query-service-impl")
-  implementation("org.hypertrace.core.query.service:query-service-client")
   implementation("org.hypertrace.gateway.service:gateway-service")
   implementation("org.hypertrace.gateway.service:gateway-service-impl")
   implementation("org.hypertrace.graphql:hypertrace-graphql-service")

--- a/hypertrace-federated-service/build.gradle.kts
+++ b/hypertrace-federated-service/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   implementation("org.hypertrace.entity.service:entity-service-impl")
   implementation("org.hypertrace.core.query.service:query-service")
   implementation("org.hypertrace.core.query.service:query-service-impl")
+  implementation("org.hypertrace.core.query.service:query-service-client")
   implementation("org.hypertrace.gateway.service:gateway-service")
   implementation("org.hypertrace.gateway.service:gateway-service-impl")
   implementation("org.hypertrace.graphql:hypertrace-graphql-service")
@@ -25,6 +26,7 @@ dependencies {
 
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.4")
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.1.3")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.1.3")
   implementation("org.hypertrace.core.documentstore:document-store:0.1.1")
 
   // Logging

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/FederatedService.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/FederatedService.java
@@ -41,9 +41,7 @@ public class FederatedService extends PlatformService {
   private static final String GRAPHQL_SERVICE_NAME = "hypertrace-graphql-service";
 
   private static final String ENTITY_SERVICE_ENTITY_SERVICE_CONFIG = "entity.service.config";
-  private static final String GATEWAY_SERVICE_QUERY_SERVICE_CONFIG = "query.service.config";
   private static final String QUERY_SERVICE_SERVICE_CONFIG = "service.config";
-  private static final String UI_SERVER_INIT_WAIT_TIME = "ui.server.init.wait.time";
 
   private static final String DEFAULT_CLUSTER_NAME = "default-cluster";
 

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/FederatedService.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/FederatedService.java
@@ -133,7 +133,7 @@ public class FederatedService extends PlatformService {
     });
 
     Thread uiThread = new Thread(() -> {
-      hypertraceUIServer.startWithTimeTask();
+      hypertraceUIServer.startWithTimerTask();
     });
 
     grpcThread.start();

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/FederatedService.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/FederatedService.java
@@ -43,6 +43,7 @@ public class FederatedService extends PlatformService {
   private static final String ENTITY_SERVICE_ENTITY_SERVICE_CONFIG = "entity.service.config";
   private static final String GATEWAY_SERVICE_QUERY_SERVICE_CONFIG = "query.service.config";
   private static final String QUERY_SERVICE_SERVICE_CONFIG = "service.config";
+  private static final String UI_SERVER_INIT_WAIT_TIME = "ui.server.init.wait.time";
 
   private static final String DEFAULT_CLUSTER_NAME = "default-cluster";
 
@@ -58,6 +59,9 @@ public class FederatedService extends PlatformService {
   protected void doInit() {
     serviceName = getAppConfig().getString(SERVICE_NAME_CONFIG);
     int port = getAppConfig().getInt(PORT_PATH);
+    long uiWaitTime = getAppConfig().hasPath(UI_SERVER_INIT_WAIT_TIME) ?
+            getAppConfig().getInt(UI_SERVER_INIT_WAIT_TIME) : 30;
+
     final ServerBuilder<?> serverBuilder = ServerBuilder.forPort(port);
 
     // Attribute service
@@ -100,7 +104,7 @@ public class FederatedService extends PlatformService {
 
     // start Hypertrace UI
     final Config graphQlServiceAppConfig = getServiceConfig(GRAPHQL_SERVICE_NAME);
-    hypertraceUIServer = new HypertraceUIServer(graphQlServiceAppConfig);
+    hypertraceUIServer = new HypertraceUIServer(getAppConfig(), graphQlServiceAppConfig);
   }
 
   private Config getServiceConfig(String serviceName) {
@@ -133,7 +137,7 @@ public class FederatedService extends PlatformService {
     });
 
     Thread uiThread = new Thread(() -> {
-      hypertraceUIServer.start();
+      hypertraceUIServer.startWithTimeTask();
     });
 
     grpcThread.start();

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/FederatedService.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/FederatedService.java
@@ -59,8 +59,6 @@ public class FederatedService extends PlatformService {
   protected void doInit() {
     serviceName = getAppConfig().getString(SERVICE_NAME_CONFIG);
     int port = getAppConfig().getInt(PORT_PATH);
-    long uiWaitTime = getAppConfig().hasPath(UI_SERVER_INIT_WAIT_TIME) ?
-            getAppConfig().getInt(UI_SERVER_INIT_WAIT_TIME) : 30;
 
     final ServerBuilder<?> serverBuilder = ServerBuilder.forPort(port);
 

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServer.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServer.java
@@ -93,7 +93,7 @@ public class HypertraceUIServer {
     }
   }
 
-  public void startWithTimeTask() {
+  public void startWithTimerTask() {
     String defaultTenant = graphQlServiceAppConfig.getString(DEFAULT_TENANT_ID_CONFIG);
     HypertraceUIServerTimerTask timerTask = new HypertraceUIServerTimerTask(appConfig,
             this, defaultTenant);

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServer.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServer.java
@@ -97,6 +97,8 @@ public class HypertraceUIServer {
     String defaultTenant = graphQlServiceAppConfig.getString(DEFAULT_TENANT_ID_CONFIG);
     HypertraceUIServerTimerTask timerTask = new HypertraceUIServerTimerTask(appConfig,
             this, defaultTenant);
+    LOGGER.info(String.format("Staring a timer task for checking health for bootstrapping process, " +
+            "will try first attempt after [%s] seconds", timerTask.getStartPeriod()));
     new Timer().scheduleAtFixedRate(timerTask, timerTask.getStartPeriod() * 1000,
             timerTask.getInterval() * 1000);
   }

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServer.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServer.java
@@ -97,7 +97,7 @@ public class HypertraceUIServer {
     String defaultTenant = graphQlServiceAppConfig.getString(DEFAULT_TENANT_ID_CONFIG);
     HypertraceUIServerTimerTask timerTask = new HypertraceUIServerTimerTask(appConfig,
             this, defaultTenant);
-    LOGGER.info(String.format("Staring a timer task for checking health for bootstrapping process, " +
+    LOGGER.info(String.format("Starting a timer task for checking health for bootstrapping process, " +
             "will try first attempt after [%s] seconds", timerTask.getStartPeriod()));
     new Timer().scheduleAtFixedRate(timerTask, timerTask.getStartPeriod() * 1000,
             timerTask.getInterval() * 1000);

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
@@ -1,0 +1,143 @@
+package org.hypertrace.federated.service;
+
+import static org.hypertrace.core.query.service.util.QueryRequestUtil.createTimeFilter;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import io.grpc.Channel;
+import io.grpc.ClientInterceptors;
+import io.grpc.Deadline;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import org.hypertrace.core.grpcutils.client.GrpcClientRequestContextUtil;
+import org.hypertrace.core.query.service.QueryServiceImplConfig;
+import org.hypertrace.core.query.service.api.ColumnIdentifier;
+import org.hypertrace.core.query.service.api.Expression;
+import org.hypertrace.core.query.service.api.Filter;
+import org.hypertrace.core.query.service.api.Operator;
+import org.hypertrace.core.query.service.api.QueryRequest;
+import org.hypertrace.core.query.service.api.QueryRequest.Builder;
+import org.hypertrace.core.query.service.api.QueryServiceGrpc;
+import org.hypertrace.core.query.service.api.ResultSetChunk;
+import org.hypertrace.core.query.service.client.QueryServiceClient;
+import org.hypertrace.core.query.service.client.QueryServiceConfig;
+import org.hypertrace.gateway.service.GatewayServiceGrpc;
+import org.hypertrace.gateway.service.GatewayServiceGrpc.GatewayServiceBlockingStub;
+import org.hypertrace.gateway.service.v1.span.Spans;
+import org.hypertrace.gateway.service.v1.span.SpansRequest;
+import org.hypertrace.gateway.service.v1.span.SpansResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HypertraceUIServerTimerTask extends TimerTask {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HypertraceUIServerTimerTask.class);
+
+  private int numTries;
+  private int maxTries;
+  private int timeout;
+  private final HypertraceUIServer uiServer;
+  //private final QueryServiceClient client;
+  private final Map<String, String> contextMap;
+  GatewayServiceBlockingStub client;
+
+  public HypertraceUIServerTimerTask(int maxTries, int timeout, String defaultTenantId,
+                                     HypertraceUIServer uiServer) {
+    this.maxTries = maxTries;
+    this.uiServer = uiServer;
+    this.numTries = 0;
+    this.timeout = timeout;
+    this.contextMap = Map.of("x-tenant-id", defaultTenantId);
+
+    /*Config config = ConfigFactory.parseMap(Map.of("host", "localhost",
+            "port", "9001"));
+    QueryServiceConfig queryServiceConfig = new QueryServiceConfig(config);
+    client = new QueryServiceClient(queryServiceConfig);*/
+
+    ManagedChannel managedChannel =
+            ManagedChannelBuilder.forAddress(
+                    "localhost", 9001)
+                    .usePlaintext()
+                    .build();
+    client = GatewayServiceGrpc.newBlockingStub(managedChannel);
+  }
+
+  @Override
+  public void run() {
+    try {
+      if (numTries >= maxTries || executeHealthCheck(buildSpanRequest(), contextMap, 2*1000)) {
+        cancel();
+        LOGGER.info(String.format("Starting UI server after [%s] attempts for config bootstrap", numTries));
+        uiServer.start();
+      }
+    } catch (Exception ex) {
+      LOGGER.info("Failed in checking attributes from query service, so it is not up");
+    }
+    numTries++;
+    LOGGER.info(String.format("Checking for for bootstrapper job to finish, attempt:[%s]", numTries));
+  }
+
+  /*private boolean executeHealthCheck() {
+    Iterator<ResultSetChunk> iterator = client.executeQuery(buildSimpleQuery(), contextMap, timeout*1000);
+    if (iterator.hasNext()) {
+      ResultSetChunk resultSetChunk = iterator.next();
+      return resultSetChunk.getHasError();
+    }
+    return false;
+  }
+
+  private QueryRequest buildSimpleQuery() {
+    Builder builder = QueryRequest.newBuilder();
+    ColumnIdentifier spanId = ColumnIdentifier.newBuilder().setColumnName("EVENT.id").build();
+    builder.addSelection(Expression.newBuilder().setColumnIdentifier(spanId).build());
+
+    Filter startTimeFilter =
+            createTimeFilter(
+                    "EVENT.start_time_millis",
+                    Operator.GT,
+                    System.currentTimeMillis() - 1000 * 60);
+    Filter endTimeFilter =
+            createTimeFilter("EVENT.end_time_millis", Operator.LT, System.currentTimeMillis());
+
+    Filter andFilter =
+            Filter.newBuilder()
+                    .setOperator(Operator.AND)
+                    .addChildFilter(startTimeFilter)
+                    .addChildFilter(endTimeFilter)
+                    .build();
+    builder.setFilter(andFilter);
+
+    return builder.build();
+  }*/
+
+  private void buildSimpleSpansQuery() {
+    ManagedChannel managedChannel =
+            ManagedChannelBuilder.forAddress(
+                    "localhost", 9001)
+                    .usePlaintext()
+                    .build();
+    GatewayServiceBlockingStub blockingStub = GatewayServiceGrpc.newBlockingStub(managedChannel);
+
+  }
+
+  private boolean executeHealthCheck(
+          SpansRequest request, Map<String, String> context, int timeoutMillis) {
+    SpansResponse response = GrpcClientRequestContextUtil.executeWithHeadersContext(
+            context,
+            () -> client.withDeadline(Deadline.after(timeoutMillis, TimeUnit.MILLISECONDS))
+                            .getSpans(request));
+    if (response.getSpansCount() >= 0) { return true; }
+    return false;
+  }
+
+  private SpansRequest buildSpanRequest() {
+    return SpansRequest.newBuilder()
+            .setStartTimeMillis(System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(10))
+            .setEndTimeMillis(System.currentTimeMillis()).setLimit(1).build();
+  }
+}

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
@@ -70,8 +70,8 @@ public class HypertraceUIServerTimerTask extends TimerTask {
     try {
       if (numTries >= maxTries) {
         cancel();
-        LOGGER.info(String.format("Max out attempt [%s] in checking bootstrapping. Manually check " +
-                "the status of all-view-creator, and config-bootstrapper.", numTries));
+        LOGGER.info(String.format("Max out attempts [%s] in checking bootstrapping status. Manually check " +
+                "the status of jobs [all-view-creator, config-bootstrapper].", numTries));
         uiServer.start();
         return;
       }
@@ -85,12 +85,12 @@ public class HypertraceUIServerTimerTask extends TimerTask {
       }
 
     } catch (Exception ex) {
-      LOGGER.warn("Failure in healthcheck status of dependent service. The bootstrapping jobs " +
-              "all-view-creator, and config-bootstrapper might not have finished yet.");
+      LOGGER.warn(String.format("Finished an attempt [%s] in checking for bootstrapping status. " +
+              "It seems bootstrapping jobs [all-view-creators, config-bootstrapper] have not yet finished. " +
+              "will retry after [%s] seconds", numTries, interval));
+    } finally {
+      numTries++;
     }
-    numTries++;
-    LOGGER.info(String.format("Finished an attempt [%s] in checking for bootstrapping status, " +
-            "will retry after [%s] seconds", numTries, interval));
   }
 
   private boolean executeHealthCheck() {

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
@@ -1,143 +1,110 @@
 package org.hypertrace.federated.service;
 
-import static org.hypertrace.core.query.service.util.QueryRequestUtil.createTimeFilter;
-
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import io.grpc.Channel;
-import io.grpc.ClientInterceptors;
 import io.grpc.Deadline;
-import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.time.Instant;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import org.hypertrace.core.grpcutils.client.GrpcClientRequestContextUtil;
-import org.hypertrace.core.query.service.QueryServiceImplConfig;
-import org.hypertrace.core.query.service.api.ColumnIdentifier;
-import org.hypertrace.core.query.service.api.Expression;
-import org.hypertrace.core.query.service.api.Filter;
-import org.hypertrace.core.query.service.api.Operator;
-import org.hypertrace.core.query.service.api.QueryRequest;
-import org.hypertrace.core.query.service.api.QueryRequest.Builder;
-import org.hypertrace.core.query.service.api.QueryServiceGrpc;
-import org.hypertrace.core.query.service.api.ResultSetChunk;
-import org.hypertrace.core.query.service.client.QueryServiceClient;
-import org.hypertrace.core.query.service.client.QueryServiceConfig;
+import org.hypertrace.core.grpcutils.client.RequestContextClientCallCredsProviderFactory;
 import org.hypertrace.gateway.service.GatewayServiceGrpc;
 import org.hypertrace.gateway.service.GatewayServiceGrpc.GatewayServiceBlockingStub;
-import org.hypertrace.gateway.service.v1.span.Spans;
+import org.hypertrace.gateway.service.common.util.QueryExpressionUtil;
 import org.hypertrace.gateway.service.v1.span.SpansRequest;
 import org.hypertrace.gateway.service.v1.span.SpansResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Helper TimerTask for checking health of dependency data services before starting UI server
+ */
 public class HypertraceUIServerTimerTask extends TimerTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(HypertraceUIServerTimerTask.class);
 
+  private static final String RETRIES_CONFIG = "hypertraceUI.init.waittime.retries";
+  private static final int DEFAULT_RETRIES = 10;
+  private static final String TIMEOUT_CONFIG = "hypertraceUI.init.waittime.timeout";
+  private static final int DEFAULT_TIMEOUT = 2;
+  private static final String INTERVAL = "hypertraceUI.init.waittime.interval";
+  private static final int DEFAULT_INTERVAL = 5;
+  private static final String START_PERIOD = "hypertraceUI.init.waittime.start_period";
+  private static final int DEFAULT_START_PERIOD = 20;
+  private final HypertraceUIServer uiServer;
+  private final GatewayServiceBlockingStub client;
   private int numTries;
   private int maxTries;
   private int timeout;
-  private final HypertraceUIServer uiServer;
-  //private final QueryServiceClient client;
-  private final Map<String, String> contextMap;
-  GatewayServiceBlockingStub client;
+  private long startTime;
+  private long interval;
+  private long startPeriod;
+  private String defaultTenant;
 
-  public HypertraceUIServerTimerTask(int maxTries, int timeout, String defaultTenantId,
-                                     HypertraceUIServer uiServer) {
-    this.maxTries = maxTries;
+  public HypertraceUIServerTimerTask(Config appConfig, HypertraceUIServer uiServer, String defaultTenant) {
+    maxTries = appConfig.hasPath(RETRIES_CONFIG) ? appConfig.getInt(RETRIES_CONFIG) : DEFAULT_RETRIES;
+    timeout = appConfig.hasPath(TIMEOUT_CONFIG) ? appConfig.getInt(TIMEOUT_CONFIG) : DEFAULT_TIMEOUT;
+    interval = appConfig.hasPath(INTERVAL) ? appConfig.getInt(INTERVAL) : DEFAULT_INTERVAL;
+    startPeriod = appConfig.hasPath(START_PERIOD) ? appConfig.getInt(START_PERIOD) : DEFAULT_START_PERIOD;
+
     this.uiServer = uiServer;
     this.numTries = 0;
-    this.timeout = timeout;
-    this.contextMap = Map.of("x-tenant-id", defaultTenantId);
+    this.defaultTenant = defaultTenant;
+    this.startTime = Instant.now().toEpochMilli();
 
-    /*Config config = ConfigFactory.parseMap(Map.of("host", "localhost",
-            "port", "9001"));
-    QueryServiceConfig queryServiceConfig = new QueryServiceConfig(config);
-    client = new QueryServiceClient(queryServiceConfig);*/
+    client = GatewayServiceGrpc.newBlockingStub(ManagedChannelBuilder.forAddress(
+            "localhost", appConfig.getInt("service.port")).usePlaintext().build())
+            .withCallCredentials(RequestContextClientCallCredsProviderFactory
+                    .getClientCallCredsProvider().get());
+  }
 
-    ManagedChannel managedChannel =
-            ManagedChannelBuilder.forAddress(
-                    "localhost", 9001)
-                    .usePlaintext()
-                    .build();
-    client = GatewayServiceGrpc.newBlockingStub(managedChannel);
+  public long getStartPeriod() {
+    return startPeriod;
+  }
+
+  public long getInterval() {
+    return interval;
   }
 
   @Override
   public void run() {
     try {
-      if (numTries >= maxTries || executeHealthCheck(buildSpanRequest(), contextMap, 2*1000)) {
+      if (numTries >= maxTries) {
         cancel();
-        LOGGER.info(String.format("Starting UI server after [%s] attempts for config bootstrap", numTries));
+        LOGGER.info(String.format("Max out attempt [%s] in checking bootstrapping. Manually check " +
+                "the status of pinot, all-view-creator, and config-bootstrapper.", numTries));
         uiServer.start();
+        return;
       }
+
+      if (executeHealthCheck()) {
+        cancel();
+        LOGGER.info(String.format("Stack is up after [%s] attempts, and duration [%s] in millis.",
+                numTries, Instant.now().toEpochMilli() - startTime));
+        uiServer.start();
+        return;
+      }
+
     } catch (Exception ex) {
-      LOGGER.info("Failed in checking attributes from query service, so it is not up");
+      LOGGER.warn("Failure in dependent service health check. Few data services like pinot is not yet up");
     }
     numTries++;
-    LOGGER.info(String.format("Checking for for bootstrapper job to finish, attempt:[%s]", numTries));
+    LOGGER.info(String.format("Finished an attempt [%s] in checking for bootstrapping status, " +
+            "will retry after [%s] seconds", numTries, interval));
   }
 
-  /*private boolean executeHealthCheck() {
-    Iterator<ResultSetChunk> iterator = client.executeQuery(buildSimpleQuery(), contextMap, timeout*1000);
-    if (iterator.hasNext()) {
-      ResultSetChunk resultSetChunk = iterator.next();
-      return resultSetChunk.getHasError();
-    }
-    return false;
-  }
-
-  private QueryRequest buildSimpleQuery() {
-    Builder builder = QueryRequest.newBuilder();
-    ColumnIdentifier spanId = ColumnIdentifier.newBuilder().setColumnName("EVENT.id").build();
-    builder.addSelection(Expression.newBuilder().setColumnIdentifier(spanId).build());
-
-    Filter startTimeFilter =
-            createTimeFilter(
-                    "EVENT.start_time_millis",
-                    Operator.GT,
-                    System.currentTimeMillis() - 1000 * 60);
-    Filter endTimeFilter =
-            createTimeFilter("EVENT.end_time_millis", Operator.LT, System.currentTimeMillis());
-
-    Filter andFilter =
-            Filter.newBuilder()
-                    .setOperator(Operator.AND)
-                    .addChildFilter(startTimeFilter)
-                    .addChildFilter(endTimeFilter)
-                    .build();
-    builder.setFilter(andFilter);
-
-    return builder.build();
-  }*/
-
-  private void buildSimpleSpansQuery() {
-    ManagedChannel managedChannel =
-            ManagedChannelBuilder.forAddress(
-                    "localhost", 9001)
-                    .usePlaintext()
-                    .build();
-    GatewayServiceBlockingStub blockingStub = GatewayServiceGrpc.newBlockingStub(managedChannel);
-
-  }
-
-  private boolean executeHealthCheck(
-          SpansRequest request, Map<String, String> context, int timeoutMillis) {
-    SpansResponse response = GrpcClientRequestContextUtil.executeWithHeadersContext(
-            context,
-            () -> client.withDeadline(Deadline.after(timeoutMillis, TimeUnit.MILLISECONDS))
-                            .getSpans(request));
-    if (response.getSpansCount() >= 0) { return true; }
-    return false;
+  private boolean executeHealthCheck() {
+    SpansResponse response = GrpcClientRequestContextUtil.executeInTenantContext(defaultTenant,
+            () -> client.withDeadline(Deadline.after(timeout, TimeUnit.SECONDS))
+                    .getSpans(buildSpanRequest()));
+    return response.getSpansCount() >= 0;
   }
 
   private SpansRequest buildSpanRequest() {
     return SpansRequest.newBuilder()
             .setStartTimeMillis(System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(10))
-            .setEndTimeMillis(System.currentTimeMillis()).setLimit(1).build();
+            .setEndTimeMillis(System.currentTimeMillis())
+            .addSelection(QueryExpressionUtil.getColumnExpression("EVENT.id"))
+            .setLimit(1)
+            .build();
   }
 }

--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
@@ -71,7 +71,7 @@ public class HypertraceUIServerTimerTask extends TimerTask {
       if (numTries >= maxTries) {
         cancel();
         LOGGER.info(String.format("Max out attempt [%s] in checking bootstrapping. Manually check " +
-                "the status of pinot, all-view-creator, and config-bootstrapper.", numTries));
+                "the status of all-view-creator, and config-bootstrapper.", numTries));
         uiServer.start();
         return;
       }
@@ -85,7 +85,8 @@ public class HypertraceUIServerTimerTask extends TimerTask {
       }
 
     } catch (Exception ex) {
-      LOGGER.warn("Failure in dependent service health check. Few data services like pinot is not yet up");
+      LOGGER.warn("Failure in healthcheck status of dependent service. The bootstrapping jobs " +
+              "all-view-creator, and config-bootstrapper might not have finished yet.");
     }
     numTries++;
     LOGGER.info(String.format("Finished an attempt [%s] in checking for bootstrapping status, " +

--- a/hypertrace-federated-service/src/main/resources/configs/hypertrace-federated-service/application.conf
+++ b/hypertrace-federated-service/src/main/resources/configs/hypertrace-federated-service/application.conf
@@ -1,5 +1,16 @@
 main.class = org.hypertrace.federated.service.FederatedService
 service.name = hypertrace-federated-service
 service.port = 9001
-
 service.admin.port = 9002
+
+hypertraceUI {
+  health.check.timeout = 2
+  health.check.timeout = ${?UI_HEALTHCHECK_TIMEOUT}
+  health.check.interval = 5
+  health.check.interval = ${?UI_HEALTHCHECK_INTERVAL}
+  health.check.retries = 18
+  health.check.retries = ${?UI_HEALTHCHECK_RETRIES}
+  health.check.start_period = 20
+  health.check.start_period = ${?UI_HEALTHCHECK_START_PERIOD}
+}
+

--- a/hypertrace-federated-service/src/main/resources/configs/hypertrace-federated-service/application.conf
+++ b/hypertrace-federated-service/src/main/resources/configs/hypertrace-federated-service/application.conf
@@ -12,7 +12,7 @@ hypertraceUI {
     interval = ${?INTERVAL}
     retries = 30
     retries = ${?RETRIES}
-    start_period = 20
+    start_period = 10
     start_period = ${?START_PERIOD}
   }
 }

--- a/hypertrace-federated-service/src/main/resources/configs/hypertrace-federated-service/application.conf
+++ b/hypertrace-federated-service/src/main/resources/configs/hypertrace-federated-service/application.conf
@@ -4,13 +4,16 @@ service.port = 9001
 service.admin.port = 9002
 
 hypertraceUI {
-  health.check.timeout = 2
-  health.check.timeout = ${?UI_HEALTHCHECK_TIMEOUT}
-  health.check.interval = 5
-  health.check.interval = ${?UI_HEALTHCHECK_INTERVAL}
-  health.check.retries = 18
-  health.check.retries = ${?UI_HEALTHCHECK_RETRIES}
-  health.check.start_period = 20
-  health.check.start_period = ${?UI_HEALTHCHECK_START_PERIOD}
+  port = 2020
+  init.waittime {
+    timeout = 2
+    timeout = ${?TIMEOUT}
+    interval = 5
+    interval = ${?INTERVAL}
+    retries = 30
+    retries = ${?RETRIES}
+    start_period = 20
+    start_period = ${?START_PERIOD}
+  }
 }
 


### PR DESCRIPTION
This PR will help as an immediate fix for checking the bootstrapping status process. 
- Provides an immediate fix for the issue -  https://github.com/hypertrace/hypertrace/issues/36
- will also allow for configuring wait time for bootstrapping process by start_period, interval, timeout, and retries
- the configuration is also exposed as ENVs

As mentioned in the issue,
- will first start grpc server
- wait for bootstrapping to finish for a configurable time
- will start UI server after configured timeout