### PR TITLE
adding main branch to avoid submodule error related to master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,20 @@
 [submodule "attribute-service"]
 	path = attribute-service
 	url = https://github.com/hypertrace/attribute-service.git
+	branch = main
 [submodule "entity-service"]
 	path = entity-service
 	url = https://github.com/hypertrace/entity-service.git
+	branch = main
 [submodule "gateway-service"]
 	path = gateway-service
 	url = https://github.com/hypertrace/gateway-service.git
+	branch = main
 [submodule "query-service"]
 	path = query-service
 	url = https://github.com/hypertrace/query-service.git
+	branch = main
 [submodule "hypertrace-graphql"]
 	path = hypertrace-graphql
 	url = https://github.com/hypertrace/hypertrace-graphql.git
+	branch = main


### PR DESCRIPTION
Was getting an error while doing an upgrade, so adding the `main` branch into a submodule.

Error:
```
➜  hypertrace-federated-service git:(update-sub-modules) ✗  git submodule update --remote attribute-service                        [20/08/31|11:59AM]
fatal: Needed a single revision
Unable to find current origin/master revision in submodule path 'attribute-service'
```