### PR TITLE
adds additional health check for pinot

### DIFF
--- a/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
+++ b/hypertrace-federated-service/src/main/java/org/hypertrace/federated/service/HypertraceUIServerTimerTask.java
@@ -1,13 +1,11 @@
 package org.hypertrace.federated.service;
 
-import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannelBuilder;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.URI;
 import java.net.URL;
 import java.time.Instant;
 import java.util.TimerTask;
@@ -148,12 +146,11 @@ public class HypertraceUIServerTimerTask extends TimerTask {
       con.connect();
       int status = con.getResponseCode();
 
-      if (status >= 200 && status <= 206) {
-          return true;
-      }
-      return false;
+      return status >= 200 && status <= 206;
     } finally {
-      if (con != null) { con.disconnect(); }
+      if (con != null) {
+        con.disconnect();
+      }
     }
   }
 
@@ -178,13 +175,13 @@ public class HypertraceUIServerTimerTask extends TimerTask {
         }
         in.close();
         String trimmed = content.toString().trim();
-        if (trimmed != null && trimmed.contains("DefaultTenant")) {
-          return true;
-        }
+        return trimmed != null && trimmed.contains("DefaultTenant");
       }
       return false;
     } finally {
-      if (con != null) { con.disconnect(); }
+      if (con != null) {
+        con.disconnect();
+      }
     }
   }
 }

--- a/hypertrace-federated-service/src/main/resources/configs/hypertrace-federated-service/application.conf
+++ b/hypertrace-federated-service/src/main/resources/configs/hypertrace-federated-service/application.conf
@@ -24,4 +24,12 @@ hypertraceUI {
     retries = ${?SHOULD_EXIT}
   }
 }
+pinot {
+  server_host = "pinot-controller"
+  server_host = ${?PINOT_SERVER_HOST}
+  server_port = 8097
+  server_port = ${?PINOT_SERVER_PORT}
+  controller_port = 9000
+  controller_port = ${?PINOT_CONTROLLER_PORT}
+}
 


### PR DESCRIPTION
With the help of this PR, it will first check if the pinot is up or not, and then it will try for the final e2e request. This will help in a lot of error logs reductions due to pinot is not yet healthy.